### PR TITLE
Update Timer.jsx

### DIFF
--- a/web/src/components/misc/Timer.jsx
+++ b/web/src/components/misc/Timer.jsx
@@ -21,8 +21,5 @@ export const Timer = ({ expiryTimestamp, children }) => {
 
 Timer.propTypes = {
   expiryTimestamp: PropTypes.instanceOf(Date),
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]),
+  children: PropTypes.func,
 };


### PR DESCRIPTION
Changed the type of the `children` prop to `PropTypes.func`. Since the children of the `Timer` component are being returned by a function, the `propType` needs to be set appropriately.